### PR TITLE
Refine arguments on trust as a release engineering problem 

### DIFF
--- a/posts/data-science-in-a-glass-box/index.qmd
+++ b/posts/data-science-in-a-glass-box/index.qmd
@@ -15,19 +15,15 @@ One criticism of that philosophy is understandable.
 
 > Does putting everything into one box simply create a bigger black box?
 
-I think the opposite is true.
+I'd argue it's the opposite. The more responsibility a platform takes on, the more transparent it should become. A mature analytics platform shouldn't just produce datasets. It should produce evidence. Every release should explain where it came from, what changed, and why it deserves to be trusted.
 
-The more responsibility a platform takes on, the more transparent it should become. A mature analytics platform shouldn't just produce datasets. It should produce evidence. Every release should explain where it came from, what changed, and why it deserves to be trusted.
-
-That has led me to think about trust a little differently.
-
-Rather than treating trust as a dashboard problem or a data quality problem, I've started thinking of it as a **release engineering problem**.
+That has led me to think about trust a little differently. Rather than treating trust as a dashboard problem or a data quality problem, I've started thinking of it as a **release engineering problem**.
 
 ## Trust is usually treated as an afterthought
 
 Imagine opening a dashboard on Monday morning and noticing that a familiar metric has changed.
 
-The first questions are almost always the same.
+The first questions are almost always the same:
 
 - What changed?
 - Was the change expected?
@@ -40,19 +36,13 @@ Most analytics platforms don't have particularly good answers.
 
 If you're lucky, there is a pull request describing the code changes. Maybe someone remembers that an upstream provider republished a file. Maybe there's a CI log showing that the pipeline passed.
 
-Those things are useful, but they aren't evidence.
+Those things are useful, but they aren't the same as evidence.
 
-Once the next deployment runs, much of that context disappears. The warehouse moves forward. CI logs age out. The "latest" tables overwrite yesterday's state. Six months later, reconstructing why a release happened often becomes an archaeological exercise.
+Once the next deployment runs, much of that context evaporates. The warehouse moves forward. Logs age out. The "latest" tables overwrite yesterday's state. Six months later, reconstructing why a release happened often becomes an archaeological excavation.
 
-That feels strange when compared to software engineering.
+We tend to think of publishing data as shipping it. The pipeline builds, the tables are updated, and we move on to the next release.
 
-Software releases are treated as first-class artifacts. They have versions, release notes, provenance, and deployment history. We expect to be able to answer questions about a release long after it has shipped.
-
-Data releases deserve the same treatment.
-
-We tend to think of publishing data as shipping it. The pipeline finishes, the tables are updated, and we move on to the next release.
-
-But software releases aren't simply shipped—they're curated. They carry documentation, version history, release notes, and enough context that someone else can understand exactly what changed and why.
+But software releases aren't simply shipped, they're curated. They carry documentation, version history, release notes, and enough context that someone else can understand exactly what changed and why.
 
 I think data releases deserve the same level of care.
 
@@ -62,11 +52,15 @@ That's the kind of transparency I'm after. Transparency into why a release deser
 
 ## Transparency is the feature
 
+Before going further, it's worth saying that this isn't a universal blueprint. If you're processing billions of streaming events or continuously rebuilding operational datasets, the economics are different. There may never be a single "release" worth preserving.
+
+The systems I am building sit at the opposite end of that spectrum. They ingest periodic updates from public agencies, produce curated analytical datasets, and then remain stable until the next release. In that environment, preserving the context around a release is often just as valuable as preserving the data itself.
+
 ![](release_cycle.png){width=800px fig-align="center"}
 
 A black box asks consumers to trust its outputs. A glass box lets them inspect them. A transparent system produces enough evidence that trust becomes a consequence rather than a requirement.
 
-It's a key distinction.
+That's a key distinction.
 
 Transparency isn't about exposing every SQL statement or expecting analysts to inspect execution plans. It means that every published release carries enough context to answer questions like:
 
@@ -86,9 +80,7 @@ Thinking in terms of releases changes the shape of the system. A release is no l
 
 Like a museum exhibit, the data itself is only part of the story. The labels, the historical context, and the documentation are what make the exhibit meaningful.
 
-A data release should work the same way. The tables are only part of the release.
-
-Equally important is the information that explains those tables: what changed, how they were produced, why they were considered safe to publish, and whether they can be reproduced in the future.
+A data release should work the same way. The tables in the dataset are only part of the release. Equally important is the information that explains those tables: what changed, how they were produced, why they were considered safe to publish, and whether they can be reproduced in the future.
 
 That package of contextual information is what I'll call **release provenance**.
 
@@ -112,11 +104,11 @@ Together, these artifacts answer questions that inevitably arise after publicati
 
 > Can we reproduce exactly what we published last year?
 
-Without release provenance, those questions often become an exercise in digging through Git history, CI logs, and institutional memory.
-
-With it, every release becomes self-describing.
+Without release provenance, those questions often become an exercise in digging through Git history, CI logs, and institutional memory. You are reliant on people remembering what happened, rather than the system preserving the evidence. With it, every release becomes self-describing.
 
 ## The first principle: build, then promote
+
+![](critical_moment.png){width=800px fig-align="center"}
 
 One consequence of this way of thinking is that consumers should never observe a warehouse in a partially updated state. A release should be built somewhere isolated. It should be validated completely. Only then should it replace the current production release in a single atomic promotion.
 
@@ -130,17 +122,9 @@ That separation creates a natural place to ask an important question: _"Is this 
 
 ![](evidence.png){width=800px fig-align="center"}
 
-Passing automated tests is necessary, but it isn't sufficient.
+Passing automated tests is necessary, but it isn't sufficient. Tests answer whether a candidate release is internally consistent. They don't explain how it differs from the version currently in production.
 
-Tests answer whether a candidate release is internally consistent. They don't explain how it differs from the version currently in production.
-
-That comparison only exists briefly. 
-
-![](critical_moment.png){width=800px fig-align="center"}
-
-Just before promotion, both the current release and the candidate release coexist.
-
-That's the moment to capture evidence. Not merely that validation succeeded, but what actually changed.
+That comparison only exists briefly. Just before promotion, both the current release and the candidate release coexist. That's the moment to capture evidence. Not merely that validation succeeded, but what actually changed.
 
 For me, that evidence includes things like:
 
@@ -151,9 +135,7 @@ For me, that evidence includes things like:
 - aggregate statistics
 - release metadata
 
-Unlike CI logs, these artifacts aren't ephemeral.
-
-They're stored alongside each release as durable, queryable records.
+Unlike CI artifacts, these artifacts aren't ephemeral. Storing test outputs or data diffs in a CI log for 90 days is fine for incremental changes, but it doesn't preserve the context needed to understand a release months later. That evidence needs to be durable, queryable records.
 
 Months later, they can still answer:
 
@@ -163,13 +145,9 @@ Months later, they can still answer:
 
 ![](queryable_trust.png){width=600px fig-align="center"}
 
-One realization that surprised me is that QA itself can become data.
+One thing I didn't expect was that QA itself could become data. Instead of producing HTML reports or transient CI comments, release validation can produce structured datasets. Those datasets become their own historical record.
 
-Instead of producing HTML reports or transient CI comments, release validation can produce structured datasets. Those datasets become their own historical record.
-
-Instead of asking people to remember why a release happened, you can ask the system.
-
-Not because the system is infallible. Because it preserved the evidence.
+Instead of asking people to remember why a release happened, you can ask the system, because it preserved the evidence.
 
 ## A framework, not a finished methodology
 
@@ -177,17 +155,19 @@ I don't think this framework is complete. There are some real trade-offs.
 
 - How much evidence is worth keeping forever?
 - When should validation be exact versus tolerant?
-- How much review should remain human?
-- What constitutes a release in a continuously rebuilt warehouse?
+- How much review should still remain human?
+- What constitutes a release?
 
 I'm still working through those questions, but the direction feels increasingly clear.
 
-The more I think about analytics platforms, the less convinced I am that trust is something dashboards earn after publication. Trust is something the release process engineers into every published artifact.
+The more I think about the purpose of analytics, the less convinced I am that trust is something dashboards earn after publication. Trust is something the release process should engineer into every published artifact.
 
-That may be the most important lesson I've learned since writing *Data Science in a Box*.
+That might be the most important idea I've had since codifying [Data Science in a Box](/posts/data-science-in-a-box/index.qmd).
 
-Curation is about more than simply preserving artifacts. It preserves the context needed to understand them.
+**Curation is about more than simply preserving artifacts. _It preserves the context needed to understand them_**.
 
 ![](release_archive.png){width=800px fig-align="center"}
 
-I think mature analytics platforms should do the same. Not just publishing data, but curating releases.
+Curating releases isn't about expecting trust, it's about keeping the receipts. Preserving the evidence earns that trust and enables continual improvement, making sure that every release is self-describing, reproducible, and understandable long after the fact.
+
+No more guesswork and apologies. Just an auditable trail of evidence that ensures explainability. That's what turns a black box into a glass box. And that's what makes trust a release engineering problem.


### PR DESCRIPTION
This pull request significantly revises the "Data Science in a Glass Box" post to clarify its arguments, improve flow, and emphasize the importance of transparency and evidence in analytics releases. The changes make the writing more concise, update terminology, and add new explanations and images to better illustrate key concepts.

**Major content and clarity improvements:**

- Rewrote several paragraphs for clarity, conciseness, and stronger argumentation, emphasizing that transparency and evidence are central to trustworthy analytics platforms, not just afterthoughts. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L18-R26) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L43-R45)
- Added new explanations and examples to distinguish between ephemeral context (like CI logs) and durable, queryable evidence, and clarified the value of release provenance. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552R55-R63) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L89-R83) [[3]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L115-R112)

**Structural and thematic enhancements:**

- Inserted new images and reorganized sections to better illustrate the release process and the critical moment for capturing evidence. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L115-R112) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L133-R127)
- Updated the discussion of validation and QA, reframing QA artifacts as valuable, persistent data rather than transient outputs. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L154-R138) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L166-R173)

**Refinements and modernization:**

- Updated language to be more precise and modern (e.g., referring to "release engineering" and "curation"), and revised the conclusion to reinforce the main thesis and call to action.