### PR TITLE
Refine language and clarity in "Data Science in a Glass Box" post

### DIFF
--- a/posts/data-science-in-a-glass-box/index.qmd
+++ b/posts/data-science-in-a-glass-box/index.qmd
@@ -15,9 +15,9 @@ One criticism of that philosophy is understandable.
 
 > Does putting everything into one box simply create a bigger black box?
 
-I'd argue it's the opposite. The more responsibility a platform takes on, the more transparent it should become. A mature analytics platform shouldn't just produce datasets. It should produce evidence. Every release should explain where it came from, what changed, and why it deserves to be trusted.
+It certainly could. But I'd argue the goal is the opposite: The more responsibility a platform takes on, the more transparent it needs to be. A mature analytics platform shouldn't just produce seemingly accurate datasets. It should produce evidence. Every release should explain where it came from, what changed, and why it deserves to be trusted.
 
-That has led me to think about trust a little differently. Rather than treating trust as a dashboard problem or a data quality problem, I've started thinking of it as a **release engineering problem**.
+Rather than treating trust as a stakeholder problem or a data quality problem, I've started thinking of it as a **release engineering problem**.
 
 ## Trust is usually treated as an afterthought
 
@@ -32,35 +32,33 @@ The first questions are almost always the same:
 - Is this a bug?
 - Can I reproduce last week's numbers?
 
-Most analytics platforms don't have particularly good answers.
+It can be incredibly difficult to give good answers.
 
 If you're lucky, there is a pull request describing the code changes. Maybe someone remembers that an upstream provider republished a file. Maybe there's a CI log showing that the pipeline passed.
 
-Those things are useful, but they aren't the same as evidence.
+Those things are useful, but they weren't designed to preserve evidence.
 
-Once the next deployment runs, much of that context evaporates. The warehouse moves forward. Logs age out. The "latest" tables overwrite yesterday's state. Six months later, reconstructing why a release happened often becomes an archaeological excavation.
+Once the next deployment runs, much of that context evaporates. The warehouse moves forward. Logs age out. The "latest" tables overwrite yesterday's state. Six months later, reconstructing how a change was introduced often becomes an archaeological excavation.
 
 We tend to think of publishing data as shipping it. The pipeline builds, the tables are updated, and we move on to the next release.
 
 But software releases aren't simply shipped, they're curated. They carry documentation, version history, release notes, and enough context that someone else can understand exactly what changed and why.
 
-I think data releases deserve the same level of care.
+I think my data releases deserve the same level of care.
 
-Rather than shipping data like sealed crates, we should think about curating releases more like museum exhibits. The data may be the centerpiece, but it's the surrounding context (the changelog and the validation evidence) that allows someone else to understand what they're looking at months or even years later.
+Rather than shipping data like sealed crates, we should think about curating releases more like museum exhibits. The data may be the centerpiece, but it's the surrounding context (like the changelogs and validation evidence) that allows someone else to understand what they're looking at months or even years later.
 
-That's the kind of transparency I'm after. Transparency into why a release deserves to be trusted.
+That's the kind of transparency I'm after. I don't want to ask for trust, I want to be able to show the proof.
 
 ## Transparency is the feature
 
-Before going further, it's worth saying that this isn't a universal blueprint. If you're processing billions of streaming events or continuously rebuilding operational datasets, the economics are different. There may never be a single "release" worth preserving.
+Before going further, it's worth saying that this isn't a universal blueprint. If you're processing large volumes of streaming events or continuously rebuilding operational datasets, the economics are different. There may never be a single "release" worth preserving.
 
-The systems I am building sit at the opposite end of that spectrum. They ingest periodic updates from public agencies, produce curated analytical datasets, and then remain stable until the next release. In that environment, preserving the context around a release is often just as valuable as preserving the data itself.
+The systems I am building sit at the opposite end of that spectrum. They ingest periodic updates from public education agencies, produce curated static datasets, and then remain largely stable until the next release. In that world, preserving the context around a release is just as valuable (and feasible) as preserving the data itself.
 
 ![](release_cycle.png){width=800px fig-align="center"}
 
-A black box asks consumers to trust its outputs. A glass box lets them inspect them. A transparent system produces enough evidence that trust becomes a consequence rather than a requirement.
-
-That's a key distinction.
+A black box asks consumers to trust its outputs. A glass box lets them inspect them. A transparent system doesn't ask you to trust it. It gives you enough evidence to decide for yourself.
 
 Transparency isn't about exposing every SQL statement or expecting analysts to inspect execution plans. It means that every published release carries enough context to answer questions like:
 
@@ -100,11 +98,11 @@ Together, these artifacts answer questions that inevitably arise after publicati
 
 > Why did this number change?
 
-> Was this an upstream correction or a transformation change?
+> Was this an upstream correction or a change in transformation logic?
 
 > Can we reproduce exactly what we published last year?
 
-Without release provenance, those questions often become an exercise in digging through Git history, CI logs, and institutional memory. You are reliant on people remembering what happened, rather than the system preserving the evidence. With it, every release becomes self-describing.
+Without release provenance, those questions often become an exercise in digging through Git history, CI logs, and institutional memory. You are reliant on someone remembering what happened, rather than the system preserving the evidence. With it, every release becomes self-describing.
 
 ## The first principle: build, then promote
 
@@ -122,9 +120,9 @@ That separation creates a natural place to ask an important question: _"Is this 
 
 ![](evidence.png){width=800px fig-align="center"}
 
-Passing automated tests is necessary, but it isn't sufficient. Tests answer whether a candidate release is internally consistent. They don't explain how it differs from the version currently in production.
+Passing automated tests is necessary, but it isn't sufficient. Tests answer whether a candidate release is internally consistent. They don't explain how it differs from the version currently in production. They don't tell you if the changes are significant, expected, or even correct.
 
-That comparison only exists briefly. Just before promotion, both the current release and the candidate release coexist. That's the moment to capture evidence. Not merely that validation succeeded, but what actually changed.
+That comparison only exists briefly. Just before promotion, both the current release and the candidate release coexist. That's the moment to capture evidence. Not merely that validation succeeded, but what actually changed and what the impact was.
 
 For me, that evidence includes things like:
 
@@ -137,7 +135,7 @@ For me, that evidence includes things like:
 
 Unlike CI artifacts, these artifacts aren't ephemeral. Storing test outputs or data diffs in a CI log for 90 days is fine for incremental changes, but it doesn't preserve the context needed to understand a release months later. That evidence needs to be durable, queryable records.
 
-Months later, they can still answer:
+Months later, I want to be able to answer:
 
 > What changed between version v2026r3 and the version it replaced?
 
@@ -145,7 +143,7 @@ Months later, they can still answer:
 
 ![](queryable_trust.png){width=600px fig-align="center"}
 
-One thing I didn't expect was that QA itself could become data. Instead of producing HTML reports or transient CI comments, release validation can produce structured datasets. Those datasets become their own historical record.
+One thing I didn't expect was that QA itself could become data. Instead of producing HTML reports or transient CI comments, release validation can produce structured datasets. Those datasets can become their own historical record.
 
 Instead of asking people to remember why a release happened, you can ask the system, because it preserved the evidence.
 
@@ -157,10 +155,11 @@ I don't think this framework is complete. There are some real trade-offs.
 - When should validation be exact versus tolerant?
 - How much review should still remain human?
 - What constitutes a release?
+- With so much detail, how do you avoid overwhelming consumers?
 
 I'm still working through those questions, but the direction feels increasingly clear.
 
-The more I think about the purpose of analytics, the less convinced I am that trust is something dashboards earn after publication. Trust is something the release process should engineer into every published artifact.
+The more I think about how to build credibility into the data itself, the less convinced I am that trust is something dashboards can earn after publication. The release process should capture the evidence before the release ever lands.
 
 That might be the most important idea I've had since codifying [Data Science in a Box](/posts/data-science-in-a-box/index.qmd).
 
@@ -168,6 +167,8 @@ That might be the most important idea I've had since codifying [Data Science in 
 
 ![](release_archive.png){width=800px fig-align="center"}
 
-Curating releases isn't about expecting trust, it's about keeping the receipts. Preserving the evidence earns that trust and enables continual improvement, making sure that every release is self-describing, reproducible, and understandable long after the fact.
+Curating releases is ultimately about keeping the receipts. The goal isn't trust. It's proof. The trust will follow.
 
-No more guesswork and apologies. Just an auditable trail of evidence that ensures explainability. That's what turns a black box into a glass box. And that's what makes trust a release engineering problem.
+If someone comes back months later and asks why a number changed, the answer shouldn't depend on tribal memory and luck. It should already be part of the release. No more guesswork and apologies. Just an auditable paper trail of evidence that makes every change explainable.
+
+That's what turns a black box into a glass box.


### PR DESCRIPTION
This pull request revises the language and structure of the post `data-science-in-a-glass-box` to clarify the argument for transparency and evidence in data releases. The changes focus on improving the explanation of trust in analytics, emphasizing the importance of preserving context and evidence, and making the writing more direct and self-reflective.

**Clarity and Argumentation Improvements:**

* Reframed the discussion on platform responsibility and transparency, clarifying that increased responsibility requires increased transparency and that the goal is to provide evidence, not just data.
* Refined the explanation of trust, shifting from a focus on dashboards and data quality to release engineering, and emphasizing the need to show proof rather than ask for trust. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L18-R20) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L35-R61)

**Context Preservation and Evidence:**

* Strengthened the argument for preserving release context by contrasting black box and glass box approaches, and highlighting the need for durable, queryable evidence over ephemeral logs and institutional memory. [[1]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L35-R61) [[2]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L103-R105) [[3]](diffhunk://#diff-03aaf65e3a6ded295ec878d1a97538880d94e21cba1d6375632801dc69753552L140-R146)
* Expanded on the importance of capturing not just validation success but also the nature and impact of changes during release promotion.

**Release Curation Philosophy:**

* Updated the conclusion to stress that curating releases is about providing proof (not just trust), ensuring every release is explainable, and removing reliance on tribal memory.

These changes collectively make the post's argument for transparent, evidence-based data releases clearer and more actionable.